### PR TITLE
Teaser updates

### DIFF
--- a/src/components/newsletter-signup.jsx
+++ b/src/components/newsletter-signup.jsx
@@ -45,11 +45,9 @@ const NewsletterSignup = () => {
                     />
                     <div className="header__form-msg">{message}</div>
 
-                    <div class="clear footer-cta-padding">
-                        <button className="header__cta" type="submit">
-                            Join our newsletter
-                        </button>
-                    </div>
+                    <button className="header__cta" type="submit">
+                        Join our newsletter
+                    </button>
                 </div>
             </form>
         </div>

--- a/src/styles/_constants.scss
+++ b/src/styles/_constants.scss
@@ -28,6 +28,7 @@ $sprout-green-dark: #417859;
 $camp-burnt-red: #953621;
 $camp-orange: #E56138;
 $camp-yellow: #F5D340;
+$camp-pale-blue: #CDFFFF;
 
 $not-so-dark-green: #7ac09a;
 $dark-green: #439a6b;

--- a/src/styles/_mixins-helpers.scss
+++ b/src/styles/_mixins-helpers.scss
@@ -85,7 +85,7 @@
 
 @mixin pale-blue-gradient-bg {
   @include inline-link;
-  background: linear-gradient(#CDFFFF 27%, #52c2c2 100%);
+  background: linear-gradient($camp-pale-blue 27%, #52c2c2 100%);
   color: $hbp-navy;
   overflow: hidden;
 }

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -34,7 +34,7 @@
 .header__content {
   width: 100%;
 
-  @media (min-width: $md) {
+  @media (min-width: $lg) {
     width: 60%;
     margin-right: 50px;
   }

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -106,7 +106,7 @@
 }
 
 .theme__logo {
-  @media (max-width: $lg) {
+  @media (max-width: $xl) {
     display: none;
   }
 }
@@ -115,7 +115,7 @@
   width: 100%;
   height: auto;
   z-index: 0;
-  margin-top: -350px;
+  margin-top: -250px;
 
   svg {
     width: 100%;
@@ -126,14 +126,18 @@
   }
 
   @media (min-width: $lg) {
-    margin-top: -450px;
+    margin-top: -400px;
   }
 
   @media (min-width: $xl) {
-    margin-top: -550px;
+    margin-top: -500px;
   }
 
   @media (min-width: $xxl) {
+    margin-top: -550px;
+  }
+
+  @media (min-width: $xxxl) {
     margin-top: -650px;
   }
 }
@@ -152,7 +156,7 @@
 .theme__content {
   width: 100%;
 
-  @media (min-width: $lg) {
+  @media (min-width: $xl) {
     width: 60%;
   }
 }

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -12,6 +12,7 @@
   width: 100%;
   height: auto;
   z-index: 0;
+  margin-bottom: -1px;
   margin-top: -250px;
 
   svg {
@@ -99,6 +100,7 @@
 
 .theme__transition {
   margin-bottom: -20px;
+  margin-top: -1px;
   
   @media (max-width: $md) {
     margin-bottom: 0px;

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -134,7 +134,7 @@
   }
 
   @media (min-width: $xxl) {
-    margin-top: -550px;
+    margin-top: -570px;
   }
 
   @media (min-width: $xxxl) {

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -64,7 +64,7 @@
 .header__newsletter-input {
   border: 0;
   outline: 0;
-  width: 300px;
+  width: 290px;
   height: 40px;
   border-radius: 10px;
   padding: 0 0.5rem;
@@ -103,12 +103,12 @@
   margin-top: -1px;
   
   @media (max-width: $md) {
-    margin-bottom: 0px;
+    margin-bottom: 1rem;
   }
 }
 
 .theme__logo {
-  @media (max-width: $xl) {
+  @media (max-width: $lg) {
     display: none;
   }
 }
@@ -147,10 +147,10 @@
 .theme__camp {
   @include h2-text;
   text-align: center;
-  margin-bottom: 60px;
+  margin-bottom: 2rem;
 
   @media (min-width: $md) {
-    margin-bottom: 30px;
+    margin-bottom: 1.9rem;
     text-align: left;
   }
 }
@@ -158,7 +158,7 @@
 .theme__content {
   width: 100%;
 
-  @media (min-width: $xl) {
+  @media (min-width: $lg) {
     width: 60%;
   }
 }

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -5,7 +5,6 @@
 .header {
   @include pale-blue-gradient-bg;
   position: relative;
-  padding-top: 90px;
 }
 
 .header__skyline {
@@ -13,7 +12,7 @@
   height: auto;
   z-index: 0;
   margin-bottom: -1px;
-  margin-top: -250px;
+  margin-top: -300px;
 
   svg {
     width: 100%;
@@ -35,7 +34,7 @@
 .header__content {
   width: 100%;
 
-  @media (min-width: $lg) {
+  @media (min-width: $md) {
     width: 60%;
     margin-right: 50px;
   }
@@ -77,6 +76,7 @@
 
 .header__cta {
   @include primary-cta;
+  margin-top: 10px; 
 }
 
 // ---------------------------------------------------------------------------

--- a/src/styles/nav.scss
+++ b/src/styles/nav.scss
@@ -1,10 +1,10 @@
 .nav,
 .nav-mobile {
-  position: fixed;
+  position: static; // temporarily pinning the nav
   top: 0;
   left: 0;
   width: 100%;
-  background-color: none;
+  background-color: $camp-pale-blue;
   z-index: 100;
 }
 


### PR DESCRIPTION
**Updates to the 2021 Teaser based on feedback and testing**. The main updates are:
- Pinning the navbar to the top of the page (see the #design channel in slack for the conversation about this)
- Updating spacing:
   - Adding space between the text box and the CTA in the newsletter signup. 
   - Slightly shrinking the width of the text box to avoid spacing issues on small mobile screens. 
   - For small screens, adding space above and removing space below the header "Our theme this year is Camping"
   - Adding space below the text in the theme announcement section (the tree sometimes overlapped with the text). 
- Attempting to fix the single pixel gap between sections on firefox and safari (I can't retest on Safari though, since I don't have it)

**I don't think any of the changes are too noticeable, but here are some screenshots with the updated spacing:** 
![image](https://user-images.githubusercontent.com/23193756/97060997-4cd67200-1563-11eb-850d-2278fbacee95.png)
![image](https://user-images.githubusercontent.com/23193756/97061036-62e43280-1563-11eb-8591-9f97aee3553b.png)
![image](https://user-images.githubusercontent.com/23193756/97061159-dd14b700-1563-11eb-92de-78d7a0e090da.png)
![image](https://user-images.githubusercontent.com/23193756/97061173-f1f14a80-1563-11eb-8bfd-6b9fd83d69a7.png)


