### PR TITLE
Try to fix missing text in production

### DIFF
--- a/src/data/faqs.json
+++ b/src/data/faqs.json
@@ -5,7 +5,7 @@
   },
   {
     "question": "Why should I attend a virtual hackathon?",
-    "answer": "The organizing team at HackBeanpot is hard at work making sure we bring the ✨ HackBeanpot spirit ✨ to our attendees in the virtual setting with lots of interactive activities planned. Perks of attending include (but not limited to): <ul><li><b>Become a Camper:</b> Connect with other students through camper cabins, friendly competition, and campfire storytelling.</li><li><b>Advance Your Career:</b> Network with companies to secure that 💰 by attending the sponsor tabling session and meeting with mentors. </li><li><b>Learn New Skills:</b> Build cool projects, attend exciting workshops, and be inspired to learn!</li></ul>"
+    "answer": "The organizing team at HackBeanpot is hard at work making sure we bring the ✨ HackBeanpot spirit ✨ to our attendees in the virtual setting with lots of interactive activities planned. Perks of attending include (but are not limited to): <br/><b>Become a Camper:</b> Connect with other students through camper cabins, friendly competition, and campfire storytelling. <br/><b>Advance Your Career:</b> Network with companies to secure that 💰 by attending the sponsor tabling session and meeting with mentors. <br/><b>Learn New Skills:</b> Build cool projects, attend exciting workshops, and be inspired to learn!"
   },
   {
     "question": "I don't have a lot of programming experience. Are hackathons for me?",


### PR DESCRIPTION
Some of the text in one of the FAQs is missing in production, but appears fine locally. My guess is that Gatsby is having trouble converting the `<ul>` element from a string to html, so it gives up and excludes it. I'm hoping that this will fix it. 

How it currently looks in the deployed version: 
![image](https://user-images.githubusercontent.com/23193756/98772574-07180700-23b5-11eb-8c4e-4d8167799bf5.png)

How it's supposed to look: 
![image](https://user-images.githubusercontent.com/23193756/98772595-14cd8c80-23b5-11eb-9726-74d807ecba3e.png)
