### PR TITLE
Add gatsby clean to build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby clean && gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write 'src/**/*.js'",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
When we deployed the sponsorship packet changes earlier today, Daniel noticed that there was a problem which he was able to fix locally by clearing the Gatsby cache. After looking into our CircleCI deployments, we realized that it doesn't always clear the cache when deploying. The change in this PR just adds the `gatsby clean` command to our deployment process, and I've confirmed that this works locally by running `npm run-script build`.

If anyone who has more experience with gatsby (like maybe @daniaalnahdi or @feliciazhang ) could confirm that this is sound logic, that would be great!

Thank you!