### PR TITLE
Replace the current header text with the core app

### DIFF
--- a/src/components/sections/welcome.jsx
+++ b/src/components/sections/welcome.jsx
@@ -5,11 +5,14 @@ import DaytimeScene from 'images/svg/daytime-scene.jsx';
 const Welcome = () => (
     <section className="header">
         <div className="container header__content">
-            <h1 className="header__title">HackBeanpot will be back!</h1>
-            <h2 className="header__event-date">February 19-21, 2021</h2>
-            <p className="header__description">Join us for our upcoming virtual hackathon!</p>
-            <a href='schedule.pdf' role="button" className="header__cta" target="_blank" rel="noopener noreferrer">
-            See this year’s schedule
+            <h1 className="header__title">HackBeanpot 2022</h1>
+            <h4 className="header__description">Join our organizing team!</h4>
+            <a href='https://docs.google.com/forms/d/e/1FAIpQLSefJBzPmcBjenKsfOmup16hra1v3XHasPsDENbx_K3CPdeUOQ/viewform' 
+                role="button" 
+                className="header__cta" 
+                target="_blank" 
+                rel="noopener noreferrer">
+            Apply Here
             </a>
         </div>
         <div className="header__skyline">

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -63,7 +63,7 @@
 }
 
 .header__description {
-  @include large-body-text($camp-orange);
+  @include h4-text($camp-orange);
   margin-bottom: 30px;
 }
 


### PR DESCRIPTION
Replacing the CTA in the header of our website - we now want to advertise that the application to join core is open!

![image](https://user-images.githubusercontent.com/23193756/110687882-f9ca2800-81ae-11eb-8040-f66663865c20.png)
