### PR TITLE
Change the header back to the newsletter signup

### DIFF
--- a/src/components/sections/welcome.jsx
+++ b/src/components/sections/welcome.jsx
@@ -6,7 +6,7 @@ const Welcome = () => (
     <section className="header">
         <div className="container header__content">
             <h1 className="header__title">HackBeanpot 2022</h1>
-            <h4 className="header__description">Sign up for our Newsletter!</h4>
+            <h4 className="header__description">Join our mailing list to stay updated on our future adventures!</h4>
             <a href='https://hackbeanpot.us10.list-manage.com/subscribe?u=a98050d47fdae2481521f0474&id=dccd8c8431' 
                 role="button" 
                 className="header__cta" 

--- a/src/components/sections/welcome.jsx
+++ b/src/components/sections/welcome.jsx
@@ -6,13 +6,13 @@ const Welcome = () => (
     <section className="header">
         <div className="container header__content">
             <h1 className="header__title">HackBeanpot 2022</h1>
-            <h4 className="header__description">Join our organizing team!</h4>
-            <a href='https://docs.google.com/forms/d/e/1FAIpQLSefJBzPmcBjenKsfOmup16hra1v3XHasPsDENbx_K3CPdeUOQ/viewform' 
+            <h4 className="header__description">Sign up for our Newsletter!</h4>
+            <a href='https://hackbeanpot.us10.list-manage.com/subscribe?u=a98050d47fdae2481521f0474&id=dccd8c8431' 
                 role="button" 
                 className="header__cta" 
                 target="_blank" 
                 rel="noopener noreferrer">
-            Apply Here
+            Sign up Here
             </a>
         </div>
         <div className="header__skyline">


### PR DESCRIPTION
Updating the header to advertise our newsletter again @ifteda asked that we link to the full signup form in our header this time so the outreach team can get people's names (instead of just their emails). 

Edit: updated the wording based on feedback

![image](https://user-images.githubusercontent.com/23193756/112725396-6141e080-8eee-11eb-9c51-2dde8eaf1c3c.png)


